### PR TITLE
SQL Lab - Only list databases where explicit access has been granted

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -183,6 +183,17 @@ class DashboardFilter(SupersetFilter):
         return query
 
 
+class DatabaseAsyncFilter(SupersetFilter):
+
+    """List datasources for which users have explicitly been granted access"""
+
+    def apply(self, query, func):  # noqa
+        if self.has_role('Admin'):
+            return query
+        perms = self.get_view_menus('datasource_access')
+        return query.filter(self.model.perm.in_(perms))
+
+
 class DatabaseView(SupersetModelView, DeleteMixin, YamlExportMixin):  # noqa
     datamodel = SQLAInterface(models.Database)
 
@@ -324,6 +335,7 @@ class DatabaseAsync(DatabaseView):
         'allow_run_async', 'allow_run_sync', 'allow_dml',
         'allow_multi_schema_metadata_fetch',
     ]
+    base_filters = [['id', DatabaseAsyncFilter, lambda: []]]
 
 
 appbuilder.add_view_no_menu(DatabaseAsync)


### PR DESCRIPTION
Adds a new filter to the DatabaseAsync View that filters the list to databases that the user has been explicitly granted access to. 

Typically users who have the 'Alpha' role have access to all datasources. This change restricts those users to only seeing datasources that they've been explicitly been granted access to. 

Admins will still see all datasources.