### PR TITLE
Update SQL lab to support fallback list of default databases

### DIFF
--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -26,6 +26,7 @@ export const QUERY_EDITOR_SET_SELECTED_TEXT = 'QUERY_EDITOR_SET_SELECTED_TEXT';
 export const QUERY_EDITOR_PERSIST_HEIGHT = 'QUERY_EDITOR_PERSIST_HEIGHT';
 
 export const SET_DATABASES = 'SET_DATABASES';
+export const SET_DEFAULT_DB_ID = 'SET_DEFAULT_DB_ID';
 export const SET_ACTIVE_QUERY_EDITOR = 'SET_ACTIVE_QUERY_EDITOR';
 export const SET_ACTIVE_SOUTHPANE_TAB = 'SET_ACTIVE_SOUTHPANE_TAB';
 export const ADD_ALERT = 'ADD_ALERT';
@@ -194,6 +195,10 @@ export function postStopQuery(query) {
 
 export function setDatabases(databases) {
   return { type: SET_DATABASES, databases };
+}
+
+export function setDefaultDbId(db_id) {
+  return { type: SET_DEFAULT_DB_ID, db_id };
 }
 
 export function addQueryEditor(queryEditor) {

--- a/superset/assets/src/SqlLab/index.jsx
+++ b/superset/assets/src/SqlLab/index.jsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import thunkMiddleware from 'redux-thunk';
 
 import { getInitialState, sqlLabReducer } from './reducers';
+import { setDefaultDbId } from './actions';
 import { initEnhancer } from '../reduxUtils';
 import { initJQueryAjax } from '../modules/utils';
 import App from './components/App';
@@ -23,6 +24,10 @@ const state = Object.assign({}, getInitialState(bootstrapData.defaultDbId), boot
 
 const store = createStore(
   sqlLabReducer, state, compose(applyMiddleware(thunkMiddleware), initEnhancer()));
+
+// Now that the defaultDBid can change depending on access permissions
+// we want to always update it to latest value in bootstrapData
+store.dispatch(setDefaultDbId(bootstrapData.defaultDbId))
 
 // jquery hack to highlight the navbar menu
 $('a:contains("SQL Lab")').parent().addClass('active');

--- a/superset/assets/src/SqlLab/reducers.js
+++ b/superset/assets/src/SqlLab/reducers.js
@@ -230,6 +230,9 @@ export const sqlLabReducer = function (state, action) {
       });
       return Object.assign({}, state, { databases });
     },
+    [actions.SET_DEFAULT_DB_ID]() {
+      return Object.assign({}, state, { defaultDbId: action.db_id });
+    },
     [actions.REMOVE_ALERT]() {
       return removeFromArr(state, 'alerts', action.alert);
     },

--- a/superset/config.py
+++ b/superset/config.py
@@ -297,6 +297,10 @@ SQLLAB_TIMEOUT = 30
 # SQLLAB_DEFAULT_DBID
 SQLLAB_DEFAULT_DBID = None
 
+# Fallback list of default DB IDs. The first one that the user has access
+# to will be selected as the user's default.
+SQLLAB_DEFAULT_DBID_FALLBACK = []
+
 # The MAX duration (in seconds) a query can run for before being killed
 # by celery.
 SQLLAB_ASYNC_TIME_LIMIT_SEC = 60 * 60 * 6

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2692,8 +2692,23 @@ class Superset(BaseSupersetView):
     @expose('/sqllab')
     def sqllab(self):
         """SQL Editor"""
+        default_db_id = config.get('SQLLAB_DEFAULT_DBID')
+
+        # Check the fallback list and select the first db that
+        # the user has access to
+        for db_id in config.get('SQLLAB_DEFAULT_DBID_FALLBACK', []):
+            database = (
+                db.session
+                .query(models.Database)
+                .filter_by(id=db_id)
+                .one()
+            )
+            if security_manager.database_access(database):
+                default_db_id = db_id
+                break
+
         d = {
-            'defaultDbId': config.get('SQLLAB_DEFAULT_DBID'),
+            'defaultDbId': int(default_db_id),
             'common': self.common_bootsrap_payload(),
         }
         return self.render_template(


### PR DESCRIPTION
When configured, the default db for a given user will be the first database on the list that they have access to.

By default when a user opens a new tab, the current tab's database selection will be used for the new tab. If there are no open tabs, or the user is logging in for the first time, then this fallback will be used to choose the default database.