### PR TITLE
Updates SQL Lab's Save Query behaviour

### DIFF
--- a/superset/assets/src/SqlLab/actions.js
+++ b/superset/assets/src/SqlLab/actions.js
@@ -52,16 +52,22 @@ export function resetState() {
 }
 
 export function saveQuery(query) {
-  const url = '/savedqueryviewapi/api/create';
-  $.ajax({
-    type: 'POST',
-    url,
-    data: query,
-    success: () => notify.success(t('Your query was saved')),
-    error: () => notify.error(t('Your query could not be saved')),
-    dataType: 'json',
-  });
-  return { type: SAVE_QUERY };
+  return function (dispatch) {
+    const url = '/superset/save_query/';
+    $.ajax({
+      type: 'POST',
+      url,
+      data: {
+        data: JSON.stringify(query)
+      },
+      success: ((data) => {
+        dispatch(queryEditorSetTitle(query.queryEditor, query.label));
+        notify.success(t('Your query was saved'))
+      }),
+      error: () => notify.error(t('Your query could not be saved')),
+      dataType: 'json',
+    });
+  };
 }
 
 export function startQuery(query) {

--- a/superset/assets/src/SqlLab/components/SaveQuery.jsx
+++ b/superset/assets/src/SqlLab/components/SaveQuery.jsx
@@ -13,6 +13,7 @@ const propTypes = {
   dbId: PropTypes.number,
   animation: PropTypes.bool,
   onSave: PropTypes.func,
+  queryEditor: PropTypes.object,
 };
 const defaultProps = {
   defaultLabel: t('Undefined'),
@@ -41,6 +42,7 @@ class SaveQuery extends React.PureComponent {
       db_id: this.props.dbId,
       schema: this.props.schema,
       sql: this.props.sql,
+      queryEditor: this.props.queryEditor,
     };
     this.props.onSave(query);
     this.saveModal.close();

--- a/superset/assets/src/SqlLab/components/SqlEditor.jsx
+++ b/superset/assets/src/SqlLab/components/SqlEditor.jsx
@@ -226,6 +226,7 @@ class SqlEditor extends React.PureComponent {
                 onSave={this.props.actions.saveQuery}
                 schema={qe.schema}
                 dbId={qe.dbId}
+                queryEditor={qe}
               />
             </span>
             <span className="m-r-5">

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2028,6 +2028,8 @@ class Superset(BaseSupersetView):
         data = json.loads(request.form.get('data'))
         session = db.session()
         saved_query = None
+
+        # special case for queries with a label starting with *
         if data['label'].startswith('*'):
             # check for an existing query with the same label
             saved_query = session.query(SavedQuery).filter_by(label=data['label'], user_id=g.user.get_id()).order_by(SavedQuery.changed_on.desc()).first()
@@ -2463,7 +2465,7 @@ class Superset(BaseSupersetView):
         session.commit()  # shouldn't be necessary
         if not query_id:
             raise Exception(_('Query record was not created as expected.'))
-        logging.info('Triggering query: {}'.format(query.to_dict()))
+        logging.info('Triggering query_id: {}'.format(query_id))
 
         try:
             template_processor = get_template_processor(
@@ -2516,8 +2518,7 @@ class Superset(BaseSupersetView):
                 data = sql_lab.get_sql_results(
                     query_id,
                     rendered_query,
-                    return_results=True,
-                    user_name=g.user.username)
+                    return_results=True)
             payload = json.dumps(
                 data, default=utils.pessimistic_json_iso_dttm_ser, ignore_nan=True)
         except Exception as e:


### PR DESCRIPTION
Currently when you save a query in SQL Lab, you specify a label and a description and click Save. Regardless of whether or not you use the same label, each time you click Save a new saved query is created. This results is users having multiple saved queries with the same label.

This fix changes the behaviour as follows:
- If the label for a query starts with a `*` and an existing query with the same label belongs to that user, then the contents of the existing saved query are overwritten. If the user has more than one query with the same label, then the most recently edited one is overwritten.
- If the label doesn't match an existing query, then a new saved query is created.
- When a query is successfully saved, the tab name is now updated to match the query label.