### PR TITLE
Bump jinja2, SQLAlchemy, and urllib3 packages due to CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ humanize==0.5.1
 idna==2.6
 isodate==0.6.0
 itsdangerous==0.24        # via flask
-jinja2==2.10              # via flask, flask-babel
+jinja2==2.10.1            # via flask, flask-babel
 kombu==4.2.1              # via celery
 mako==1.0.7               # via alembic
 markdown==3.0
@@ -62,10 +62,10 @@ selenium==3.141.0
 simplejson==3.15.0
 six==1.11.0               # via bleach, cryptography, isodate, pathlib2, polyline, pydruid, python-dateutil, sqlalchemy-utils, wtforms-json
 sqlalchemy-utils==0.32.21
-sqlalchemy==1.2.2
+sqlalchemy==1.3.0
 sqlparse==0.2.4
 unicodecsv==0.14.1
-urllib3==1.23             # via requests, selenium
+urllib3==1.24.2           # via requests, selenium
 vine==1.1.4               # via amqp
 webencodings==0.5.1       # via bleach
 werkzeug==0.14.1          # via flask


### PR DESCRIPTION
Bump the following:
 * SQLAlchemy to 1.3.0 for CVE-2019-7548 and CVE-2019-7164
 * Jinja2 to 2.10.1 for CVE-2019-10906
 * urllib3 to 1.24.2 for CVE-2019-11324